### PR TITLE
dockerize build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get install -y \
+   build-essential \
+   curl \
+   wget \
+   libglib2.0-dev \
+   autoconf \
+   libtool \
+   unzip \
+   git \
+   valgrind \
+   pkg-config
+
+RUN wget https://github.com/lcm-proj/lcm/releases/download/v1.3.1/lcm-1.3.1.zip && \
+   unzip lcm-1.3.1.zip && \
+   cd lcm-1.3.1 && ./configure && \
+   make && \ 
+   sudo make install && \
+   sudo ldconfig  
+
+RUN curl -sL https://github.com/libcheck/check/releases/download/0.11.0/check-0.11.0.tar.gz | tar xz
+
+RUN cd check-0.11.0 && autoreconf --install && ./configure && make && make install && cd ..
+
+RUN ldconfig
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -10,4 +10,9 @@ pushd src
 lcm-gen -c say.lcm
 popd
 ```
+Alternatively, with Docker
 
+```bash
+docker build -t dogesay .
+docker run --rm -v $PWD:/home/dogesay dogesay /bin/bash -c "cd src && lcm-gen -c say.lcm"
+```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,5 @@ popd
 Alternatively, with Docker
 
 ```bash
-docker build -t dogesay .
-docker run --rm -v $PWD:/home/dogesay dogesay /bin/bash -c "cd src && lcm-gen -c say.lcm"
+./scripts/compile_lcm.sh
 ```

--- a/scripts/compile_lcm.sh
+++ b/scripts/compile_lcm.sh
@@ -1,0 +1,7 @@
+if [[ $(docker images -q dogesay:latest) == "" ]]; then 
+  docker build -t dogesay .    
+fi
+
+echo $PWD
+
+docker run --rm -v $PWD:/home/dogesay -w=/home/dogesay dogesay /bin/bash -c "cd src && lcm-gen -c say.lcm"


### PR DESCRIPTION
compile lcm without needing lcm on your system, target linux, or whatever else you can think of. 

Also installs libcheck and valgrind so you can test your code and stop living like an animal. 